### PR TITLE
Bug fix in docker-compose.yaml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,7 +74,8 @@ services:
       - "../logs:/var/log/dex-backend:rw"
       - "../data/pool-resolver/rocks:/usr/local/etc/rocks:Z"
     env_file: config.env
-    ports: [ 9876:9876 ]
+    ports:
+      - 9876:9876
     depends_on:
       - kafka1
       - redis


### PR DESCRIPTION
This will fix the error:

```
ERROR: yaml.scanner.ScannerError: while scanning a plain scalar
  in "./docker-compose.yml", line 77, column 14
found unexpected ':'
  in "./docker-compose.yml", line 77, column 18
Please check http://pyyaml.org/wiki/YAMLColonInFlowContext for details.

```